### PR TITLE
Fix build errors with latest Tesseract API

### DIFF
--- a/fuzzer-api.cpp
+++ b/fuzzer-api.cpp
@@ -1,5 +1,5 @@
-#include "baseapi.h"
-#include "leptonica/allheaders.h"
+#include <leptonica/allheaders.h>
+#include <tesseract/baseapi.h>
 
 #include <stdint.h>
 #include <stddef.h>


### PR DESCRIPTION
Tesseract changed the recommended way how to include API header files.
Use <> instead of "" also for the Leptonica API header file.

Signed-off-by: Stefan Weil <sw@weilnetz.de>